### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 title = "mdBook Pikchr"
 authors = ["Konstantin Podsvirov <konstantin@podsvirov.pro>"]
-multilingual = false
 language = "en"
 src = "docs"
 


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10